### PR TITLE
msm: vidc: disable CPU L2 cache PC during video sessions

### DIFF
--- a/drivers/media/platform/msm/vidc/msm_v4l2_vidc.c
+++ b/drivers/media/platform/msm/vidc/msm_v4l2_vidc.c
@@ -20,6 +20,7 @@
 #include <linux/of_platform.h>
 #include <linux/platform_device.h>
 #include <linux/slab.h>
+#include <linux/pm_qos.h>
 #include <linux/types.h>
 #include <linux/version.h>
 #include <linux/io.h>
@@ -34,6 +35,7 @@
 
 #define BASE_DEVICE_NUMBER 32
 
+static struct pm_qos_request msm_v4l2_vidc_pm_qos_request;
 struct msm_vidc_drv *vidc_driver;
 
 uint32_t msm_vidc_pwr_collapse_delay = 2000;
@@ -60,6 +62,11 @@ static int msm_v4l2_open(struct file *filp)
 		core->id, vid_dev->type);
 		return -ENOMEM;
 	}
+	
+		dprintk(VIDC_DBG, "pm_qos_add with latency 1000usec\n");
+	        pm_qos_add_request(&msm_v4l2_vidc_pm_qos_request,
+				PM_QOS_CPU_DMA_LATENCY, 1000);
+	
 	clear_bit(V4L2_FL_USES_V4L2_FH, &vdev->flags);
 	filp->private_data = &(vidc_inst->event_handler);
 	trace_msm_v4l2_vidc_open_end("msm_v4l2_open end");
@@ -80,6 +87,12 @@ static int msm_v4l2_close(struct file *filp)
 			"Failed in %s for release output buffers\n", __func__);
 
 	rc = msm_vidc_close(vidc_inst);
+	
+	dprintk(VIDC_DBG, "pm_qos_update and remove\n");
+	pm_qos_update_request(&msm_v4l2_vidc_pm_qos_request,
+			PM_QOS_DEFAULT_VALUE);
+	pm_qos_remove_request(&msm_v4l2_vidc_pm_qos_request);
+	
 	trace_msm_v4l2_vidc_close_end("msm_v4l2_close end");
 	return rc;
 }


### PR DESCRIPTION
CPU L2 cache is being power collapsed and resumed during
video sessions which is consuming more power unnecessarily.
So disable CPU L2 cache power collapse during video sessions
using qos requests to save power.