### PR TITLE
Fpc/gpio cleanup

### DIFF
--- a/drivers/input/keyboard/gpio_keys.c
+++ b/drivers/input/keyboard/gpio_keys.c
@@ -34,6 +34,8 @@
 #include <linux/pinctrl/consumer.h>
 #include <linux/syscore_ops.h>
 
+#define HOME_KEY_CODE 102
+
 struct gpio_button_data {
 	const struct gpio_keys_button *button;
 	struct input_dev *input;
@@ -356,7 +358,7 @@ static void gpio_keys_gpio_report_event(struct gpio_button_data *bdata)
 	state = ( gpio_value ? 1 : 0) ^ button->active_low;
 	pr_info("key gpio value = %d active_low = %d  state=%d home_button_status=%d\n" , gpio_value, button->active_low, state, home_button_status);
 
-	if (state) {
+	if (state && (int)button->code == HOME_KEY_CODE) {
 		home_button_status = true;
 	}
 

--- a/drivers/misc/fpc1020_ree.c
+++ b/drivers/misc/fpc1020_ree.c
@@ -57,8 +57,14 @@ struct fpc1020_data {
 	int screen_on;
 };
 
+/*
+ * From drivers/input/keyboard/gpio_keys.c
+ */
 extern bool home_button_pressed(void);
-extern void reset_home_button(bool);
+/*
+ * From drivers/input/keyboard/gpio_keys.c
+ */
+extern void reset_home_button(void);
 
 bool reset;
 
@@ -86,7 +92,7 @@ static ssize_t irq_set(struct device* device,
 	else if (val == 0)
 		disable_irq(fpc1020->irq);
 	else
-		return -ENOENT; 
+		return -ENOENT;
 	return strnlen(buffer, count);
 }
 
@@ -156,7 +162,7 @@ static DEVICE_ATTR(wakeup, S_IRUSR | S_IWUSR, get_wakeup_status, set_wakeup_stat
 static ssize_t get_key(struct device* device, struct device_attribute* attribute, char* buffer)
 {
 	struct fpc1020_data* fpc1020 = dev_get_drvdata(device);
-		return scnprintf(buffer, PAGE_SIZE, "%i\n", fpc1020->report_key);
+	return scnprintf(buffer, PAGE_SIZE, "%i\n", fpc1020->report_key);
 }
 
 static ssize_t set_key(struct device* device,
@@ -166,29 +172,28 @@ static ssize_t set_key(struct device* device,
 	int retval = 0;
 	u64 val;
 	struct fpc1020_data* fpc1020 = dev_get_drvdata(device);
+	bool home_pressed;
 
 	retval = kstrtou64(buffer, 0, &val);
 	if (!retval) {
 		if (val == KEY_HOME)
 			val = KEY_NAVI_LONG;  //Convert to U-touch long press keyValue
-		if (val != 0 && home_button_pressed()) val = 0;
 
-		pr_info("home key pressed = %d\n", (int)home_button_pressed());
+	    home_pressed = home_button_pressed();
+
+		if (val && home_pressed) val = 0;
+
+		pr_info("home key pressed = %d\n", (int)home_pressed);
 		fpc1020->report_key = (int)val;
 		queue_work(fpc1020->fpc1020_wq, &fpc1020->input_report_work);
 
-		if (val == 0) {
+		if (!val) {
 			pr_info("calling home key reset");
-			reset_home_button(0);
+			reset_home_button();
 		}
 	} else
 		return -ENOENT;
 	return strnlen(buffer, count);
-}
-
-bool reset_gpio(void)
-{
-	return reset;
 }
 
 static DEVICE_ATTR(key, S_IRUSR | S_IWUSR, get_key, set_key);


### PR DESCRIPTION
* General improvements to code style
* Remove unused functions
* Remove redundant param for `reset_home_button`
* Reuse function calls as variables to improve performance
* Simplify boolean checks
* Document `extern` functions and relevant variables
* Only modify `home_status` if key pressed is home key